### PR TITLE
tries upgrading to 3.4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 log/
 target/
 examples/
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.datastax.tinkerpop</groupId>
     <artifactId>mongodb-gremlin</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
     <name>MongoDB-Gremlin: Compiler for MongoDB to the Gremlin Traversal Machine</name>
     <organization>
         <name>DataStax</name>
@@ -44,7 +44,7 @@
         <commons-cli.version>1.3.1</commons-cli.version>
         <commons-io.version>2.4</commons-io.version>
         <junit.version>4.12</junit.version>
-        <tinkerpop.version>3.3.0-SNAPSHOT</tinkerpop.version>
+        <tinkerpop.version>3.4.6</tinkerpop.version>
         <query.dir>src/test/resources/mongodb/queries</query.dir>
     </properties>
 

--- a/src/main/java/com/datastax/tinkerpop/mongodb/strategy/decoration/MongoDBStrategy.java
+++ b/src/main/java/com/datastax/tinkerpop/mongodb/strategy/decoration/MongoDBStrategy.java
@@ -63,6 +63,9 @@ public final class MongoDBStrategy extends AbstractTraversalStrategy<TraversalSt
 
         // PROCESS INSERT JSON OBJECT //
         if (type.equals("insert")) {
+            // which one of these is needed?
+            // Traversal<?,String> vertexLabelTraversal=null;
+            // String vertexLabel=null;
             traversal.addStep(new AddVertexStartStep(traversal, null)).as("a");
             insertMap(query, traversal);
             traversal.select("a").id().asAdmin().addStep(new MongoDBInsertStep(traversal));

--- a/src/test/java/com/datastax/tinkerpop/mongodb/MongoDBTest.java
+++ b/src/test/java/com/datastax/tinkerpop/mongodb/MongoDBTest.java
@@ -1,6 +1,7 @@
 package com.datastax.tinkerpop.mongodb;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -58,7 +59,9 @@ public class MongoDBTest {
         gremlinTraversal.iterate();
         mongoTraversal.iterate();
         for (int i = 0; i < mongoTraversal.asAdmin().getSteps().size() - 1; i++) {
-            assertEquals(mongoTraversal.asAdmin().getSteps().get(i), gremlinTraversal.asAdmin().getSteps().get(i));
+            Step mongoStep = mongoTraversal.asAdmin().getSteps().get(i);
+            Step gremlinStep = gremlinTraversal.asAdmin().getSteps().get(i);
+            assertEquals(gremlinStep,mongoStep);
         }
     }
 


### PR DESCRIPTION
Hi Marko,

when trying to fixup to 3.4.6 there were two issues:

The constructor AddVertexStartStep(Traversal.Admin, String) is ambiguous
So i tried both
            // which one of these is needed?
            // Traversal<?,String> vertexLabelTraversal=null;
            // String vertexLabel=null;	

but in all cases the shouldSupportfindDocuments test case fails.
I fixed the order of expected/found for the steps and made things easier to debug.

What needs to be done to get this to the Proof of Concept is working point again?
I might work some more on the POC ... 
